### PR TITLE
Polish docs theme: dark toggle, nav, repo link

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1,6 +1,7 @@
 PROJECT_NAME           = "simple_casadi_mpc"
 OUTPUT_DIRECTORY       = build
 OUTPUT_LANGUAGE        = English
+HTML_COLORSTYLE        = LIGHT
 
 INPUT                  = ../README.md \
                          ../include \
@@ -21,13 +22,16 @@ GENERATE_XML           = NO
 
 GENERATE_TREEVIEW      = YES
 DISABLE_INDEX          = NO
+HTML_DYNAMIC_MENUS     = YES
 
 HTML_OUTPUT            = html
 HTML_STYLESHEET        =
 HTML_EXTRA_STYLESHEET  = doxygen-awesome-css/doxygen-awesome.css \
                          doxygen-awesome-css/doxygen-awesome-sidebar-only.css \
-                         doxygen-awesome-css/doxygen-awesome-sidebar-only-darkmode-toggle.css
+                         doxygen-awesome-css/doxygen-awesome-sidebar-only-darkmode-toggle.css \
+                         custom.css
 HTML_EXTRA_FILES       = doxygen-awesome-css/doxygen-awesome-darkmode-toggle.js
+HTML_HEADER            = header.html
 
 ALPHABETICAL_INDEX     = YES
 SOURCE_BROWSER         = NO

--- a/doc/custom.css
+++ b/doc/custom.css
@@ -1,0 +1,23 @@
+:root {
+  --repo-link-bg: #2d6cdf;
+  --repo-link-text: #ffffff;
+}
+
+#projectrepo {
+  padding-left: 1em;
+  white-space: nowrap;
+}
+
+.repo-link {
+  display: inline-block;
+  padding: 6px 12px;
+  border-radius: 6px;
+  background: var(--repo-link-bg);
+  color: var(--repo-link-text);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.repo-link:hover {
+  filter: brightness(0.95);
+}

--- a/doc/header.html
+++ b/doc/header.html
@@ -1,0 +1,61 @@
+<!-- HTML header for doxygen 1.9.1-->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
+<meta http-equiv="X-UA-Compatible" content="IE=9"/>
+<meta name="generator" content="Doxygen $doxygenversion"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->
+<!--BEGIN !PROJECT_NAME--><title>$title</title><!--END !PROJECT_NAME-->
+<link href="$relpath^tabs.css" rel="stylesheet" type="text/css"/>
+<script type="text/javascript" src="$relpath^jquery.js"></script>
+<script type="text/javascript" src="$relpath^dynsections.js"></script>
+$treeview
+$search
+$mathjax
+<link href="$relpath^$stylesheet" rel="stylesheet" type="text/css" />
+$extrastylesheet
+<script type="text/javascript" src="$relpath^doxygen-awesome-css/doxygen-awesome-darkmode-toggle.js"></script>
+<script type="text/javascript">
+  DoxygenAwesomeDarkModeToggle.init();
+</script>
+</head>
+<body>
+<div id="top"><!-- do not remove this div, it is closed by doxygen! -->
+
+<!--BEGIN TITLEAREA-->
+<div id="titlearea">
+<table cellspacing="0" cellpadding="0">
+ <tbody>
+ <tr style="height: 56px;">
+  <!--BEGIN PROJECT_LOGO-->
+  <td id="projectlogo"><img alt="Logo" src="$relpath^$projectlogo"/></td>
+  <!--END PROJECT_LOGO-->
+  <!--BEGIN PROJECT_NAME-->
+  <td id="projectalign" style="padding-left: 0.5em;">
+   <div id="projectname">$projectname
+   <!--BEGIN PROJECT_NUMBER-->&#160;<span id="projectnumber">$projectnumber</span><!--END PROJECT_NUMBER-->
+   </div>
+   <!--BEGIN PROJECT_BRIEF--><div id="projectbrief">$projectbrief</div><!--END PROJECT_BRIEF-->
+  </td>
+  <!--END PROJECT_NAME-->
+  <!--BEGIN !PROJECT_NAME-->
+   <!--BEGIN PROJECT_BRIEF-->
+    <td style="padding-left: 0.5em;">
+    <div id="projectbrief">$projectbrief</div>
+    </td>
+   <!--END PROJECT_BRIEF-->
+  <!--END !PROJECT_NAME-->
+  <!--BEGIN DISABLE_INDEX-->
+   <!--BEGIN SEARCHENGINE-->
+   <td>$searchbox</td>
+   <!--END SEARCHENGINE-->
+  <!--END DISABLE_INDEX-->
+  <td id="projectrepo"><a class="repo-link" href="https://github.com/Kotakku/simple_casadi_mpc" target="_blank" rel="noopener">GitHub</a></td>
+ </tr>
+ </tbody>
+</table>
+</div>
+<!--END TITLEAREA-->
+<!-- end header part -->


### PR DESCRIPTION
## Summary
- use custom Doxygen header to initialize doxygen-awesome dark mode toggle and add a GitHub repo button
- include custom CSS for the repo link and set sidebar-only theme requirements (treeview, dynamic menus)
- ensure resources are included via HTML_HEADER/EXTRA_STYLESHEET entries

## Testing
- PRE_COMMIT_HOME=.cache/pre-commit pre-commit run --all-files
- cd doc && doxygen Doxyfile