### PR TITLE
Improve CMake packaging for CompiledMPC

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,9 @@ jobs:
           sudo apt-get install -y doxygen graphviz
 
       - name: Build docs
-        run: doxygen doc/Doxyfile
+        run: |
+          cd doc
+          doxygen Doxyfile
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ option(BUILD_BENCHMARKS "Build benchmark executables" OFF)
 
 project(simple_casadi_mpc CXX)
 
+find_package(casadi REQUIRED)
+find_package(Eigen3 REQUIRED)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS "-O3 -Wall -Wextra")
 
@@ -13,12 +16,22 @@ set(HEADER_FILES
     ${CMAKE_SOURCE_DIR}/include/simple_casadi_mpc/casadi_utils.hpp)
 
 add_library(${PROJECT_NAME} INTERFACE)
+add_library(simple_casadi_mpc::simple_casadi_mpc ALIAS ${PROJECT_NAME})
 
 target_include_directories(
   ${PROJECT_NAME} INTERFACE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
                             $<INSTALL_INTERFACE:include>)
+if(TARGET casadi::casadi)
+  target_link_libraries(${PROJECT_NAME} INTERFACE casadi::casadi)
+else()
+  target_link_libraries(${PROJECT_NAME} INTERFACE casadi)
+endif()
+target_link_libraries(${PROJECT_NAME} INTERFACE Eigen3::Eigen)
 
 include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+set(SIMPLE_CASADI_MPC_CMAKE_INSTALL_DIR
+    ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
@@ -30,15 +43,22 @@ install(
 
 install(
   EXPORT ${PROJECT_NAME}Targets
-  FILE ${PROJECT_NAME}Config.cmake
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+  FILE ${PROJECT_NAME}Targets.cmake
+  NAMESPACE simple_casadi_mpc::
+  DESTINATION ${SIMPLE_CASADI_MPC_CMAKE_INSTALL_DIR})
+
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/simple_casadi_mpcConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+  INSTALL_DESTINATION ${SIMPLE_CASADI_MPC_CMAKE_INSTALL_DIR}
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+              ${CMAKE_CURRENT_SOURCE_DIR}/cmake/simple_casadi_mpc_codegen.cmake
+        DESTINATION ${SIMPLE_CASADI_MPC_CMAKE_INSTALL_DIR})
 
 # build examples
-
 if(BUILD_EXAMPLES)
-  find_package(PkgConfig REQUIRED)
-  find_package(casadi REQUIRED)
-  find_package(Eigen3 REQUIRED)
   find_package(
     Python3
     COMPONENTS Interpreter Development NumPy
@@ -46,7 +66,6 @@ if(BUILD_EXAMPLES)
   find_package(pybind11 REQUIRED)
   find_package(matplotlibcpp17 REQUIRED)
 
-  pkg_check_modules(IPOPT REQUIRED ipopt)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
   include(simple_casadi_mpc_codegen)
 
@@ -56,70 +75,38 @@ if(BUILD_EXAMPLES)
                              PRIVATE ${CMAKE_SOURCE_DIR}/example)
   target_link_libraries(
     double_integrator_mpc_example
-    PRIVATE casadi
-            Eigen3::Eigen
-            ${PROJECT_NAME}
-            Python3::Python
-            Python3::NumPy
-            pybind11::embed
+    PRIVATE casadi Eigen3::Eigen ${PROJECT_NAME} pybind11::embed
             matplotlibcpp17::matplotlibcpp17)
 
   add_executable(cartpole_mpc_example example/cartpole_mpc_example.cpp)
   target_link_libraries(
     cartpole_mpc_example
-    PRIVATE casadi
-            Eigen3::Eigen
-            ${PROJECT_NAME}
-            Python3::Python
-            Python3::NumPy
-            pybind11::embed
+    PRIVATE casadi Eigen3::Eigen ${PROJECT_NAME} pybind11::embed
             matplotlibcpp17::matplotlibcpp17)
 
   add_executable(inverted_pendulum_mpc_example
                  example/inverted_pendulum_mpc_example.cpp)
   target_link_libraries(
     inverted_pendulum_mpc_example
-    PRIVATE casadi
-            Eigen3::Eigen
-            ${PROJECT_NAME}
-            Python3::Python
-            Python3::NumPy
-            pybind11::embed
+    PRIVATE casadi Eigen3::Eigen ${PROJECT_NAME} pybind11::embed
             matplotlibcpp17::matplotlibcpp17)
 
   add_executable(diff_drive_mpc_example example/diff_drive_mpc_example.cpp)
   target_link_libraries(
     diff_drive_mpc_example
-    PRIVATE casadi
-            Eigen3::Eigen
-            ${PROJECT_NAME}
-            Python3::Python
-            Python3::NumPy
-            pybind11::embed
+    PRIVATE casadi Eigen3::Eigen ${PROJECT_NAME} pybind11::embed
             matplotlibcpp17::matplotlibcpp17)
 
   add_executable(cartpole_mpc_jit_example example/cartpole_mpc_jit_example.cpp)
   target_link_libraries(
     cartpole_mpc_jit_example
-    PRIVATE casadi
-            Eigen3::Eigen
-            ${PROJECT_NAME}
-            Python3::Python
-            Python3::NumPy
-            pybind11::embed
+    PRIVATE casadi Eigen3::Eigen ${PROJECT_NAME} pybind11::embed
             matplotlibcpp17::matplotlibcpp17)
 
   add_simple_casadi_mpc_codegen(
-    double_integrator_problem
-    example/double_integrator_mpc_codegen.cpp
-    EXPORT_SOLVER_NAME
-    double_integrator_solver
-    INCLUDE_DIRS
-    ${CMAKE_SOURCE_DIR}/example
-    LINK_LIBS
-    fatrop
-    blasfeo)
-
+    double_integrator_problem example/double_integrator_mpc_codegen.cpp
+    EXPORT_SOLVER_NAME double_integrator_solver INCLUDE_DIRS
+    ${CMAKE_SOURCE_DIR}/example)
   add_executable(double_integrator_mpc_compiled_example
                  example/double_integrator_mpc_compiled_example.cpp)
   target_sources(
@@ -143,10 +130,8 @@ if(BUILD_EXAMPLES)
     cartpole_solver
     INCLUDE_DIRS
     ${CMAKE_SOURCE_DIR}/example
-    LINK_LIBS
-    fatrop
-    blasfeo)
-
+    SOLVER_NAME
+    ipopt)
   add_executable(cartpole_mpc_codegen_example
                  example/cartpole_mpc_codegen_example.cpp)
   target_sources(cartpole_mpc_codegen_example
@@ -161,14 +146,10 @@ if(BUILD_EXAMPLES)
     PRIVATE casadi Eigen3::Eigen ${PROJECT_NAME}
             cartpole_problem_compiled_solver pybind11::embed
             matplotlibcpp17::matplotlibcpp17)
-
 endif()
 
 # build benchmarks
 if(BUILD_BENCHMARKS)
-  find_package(PkgConfig REQUIRED)
-  find_package(casadi REQUIRED)
-  find_package(Eigen3 REQUIRED)
   find_package(
     Python3
     COMPONENTS Interpreter Development NumPy
@@ -176,21 +157,12 @@ if(BUILD_BENCHMARKS)
   find_package(pybind11 REQUIRED)
   find_package(matplotlibcpp17 REQUIRED)
 
-  pkg_check_modules(IPOPT REQUIRED ipopt)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
   include(simple_casadi_mpc_codegen)
 
   add_simple_casadi_mpc_codegen(
-    cartpole_solver_bench
-    benchmark/cartpole_mpc_codegen.cpp
-    EXPORT_SOLVER_NAME
-    cartpole_solver_bench
-    INCLUDE_DIRS
-    ${CMAKE_SOURCE_DIR}/benchmark
-    LINK_LIBS
-    fatrop
-    blasfeo)
-
+    cartpole_solver_bench benchmark/cartpole_mpc_codegen.cpp EXPORT_SOLVER_NAME
+    cartpole_solver_bench INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/benchmark)
   add_executable(cartpole_mpc_solver_bench
                  benchmark/cartpole_mpc_solver_bench.cpp)
   target_sources(cartpole_mpc_solver_bench
@@ -202,13 +174,7 @@ if(BUILD_BENCHMARKS)
                                       ${cartpole_solver_bench_CODEGEN_DIR})
   target_link_libraries(
     cartpole_mpc_solver_bench
-    PRIVATE casadi
-            Eigen3::Eigen
-            ${PROJECT_NAME}
-            cartpole_solver_bench_compiled_solver
-            Python3::Python
-            Python3::NumPy
-            pybind11::embed
+    PRIVATE casadi Eigen3::Eigen ${PROJECT_NAME}
+            cartpole_solver_bench_compiled_solver pybind11::embed
             matplotlibcpp17::matplotlibcpp17)
-
 endif()

--- a/README.md
+++ b/README.md
@@ -36,7 +36,31 @@ target_link_libraries(my_target PRIVATE simple_casadi_mpc)
 - `JITMPC`: JIT-compiles on the first solve for faster subsequent runs; expect a startup lag (cacheable with ccache).
 - `CompiledMPC`: builds solver code at CMake time; best steady-state speed with no runtime lag.
 
-Limitation for `CompiledMPC`: the solver backend (IPOPT/FATROP) and its parameters are fixed at build time.
+Limitation for `CompiledMPC`: the solver backend (IPOPT/FATROP/...) and its parameters are fixed at build time.
+
+### Usage for CompiledMPC via CMake
+```cmake
+find_package(simple_casadi_mpc REQUIRED)
+
+# Generate a compiled solver (codegen step happens at build time)
+add_simple_casadi_mpc_codegen(
+  <solver_target_name>                  # e.g., my_problem
+  <codegen_cpp>                         # e.g., my_problem_codegen.cpp (derives Problem)
+  EXPORT_SOLVER_NAME <export_name>      # optional, default is <solver_target_name>_compiled_solver
+  INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} # where your Problem header lives
+  SOLVER_NAME <casadi_solver>           # optional; default is fatrop (e.g., ipopt/fatrop/...)
+  # LINK_LIBS ...                       # optional; extra solver libs if needed
+)
+
+# Link your executable against the generated solver + simple_casadi_mpc
+add_executable(<your_exe> main.cpp
+                ${<solver_target_name>_COMPILED_SOLVER_CONFIG_SOURCE})
+target_include_directories(<your_exe> PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR} ${<solver_target_name>_CODEGEN_DIR})
+target_link_libraries(<your_exe> PRIVATE
+  simple_casadi_mpc::simple_casadi_mpc
+  ${<solver_target_name>_COMPILED_SOLVER})
+```
 
 ## Examples
 ### double_integrator_mpc_example

--- a/cmake/simple_casadi_mpcConfig.cmake.in
+++ b/cmake/simple_casadi_mpcConfig.cmake.in
@@ -1,0 +1,13 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(casadi REQUIRED)
+find_dependency(Eigen3 REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/simple_casadi_mpcTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/simple_casadi_mpc_codegen.cmake")
+
+if(NOT TARGET simple_casadi_mpc)
+  add_library(simple_casadi_mpc ALIAS simple_casadi_mpc::simple_casadi_mpc)
+endif()

--- a/cmake/simple_casadi_mpc_codegen.cmake
+++ b/cmake/simple_casadi_mpc_codegen.cmake
@@ -1,6 +1,6 @@
 function(add_simple_casadi_mpc_codegen name codegen_cpp)
   set(options)
-  set(oneValueArgs EXPORT_SOLVER_NAME)
+  set(oneValueArgs EXPORT_SOLVER_NAME LIB_TARGET SOLVER_NAME)
   set(multiValueArgs LINK_LIBS INCLUDE_DIRS)
   cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}"
                         ${ARGN})
@@ -9,23 +9,74 @@ function(add_simple_casadi_mpc_codegen name codegen_cpp)
     set(ARG_EXPORT_SOLVER_NAME ${name}_compiled_solver)
   endif()
 
-  # TODO: ipoptソルバ用のtempolaryな対応なので汎用性をもたせる
+  if(NOT ARG_LIB_TARGET)
+    if(TARGET simple_casadi_mpc::simple_casadi_mpc)
+      set(ARG_LIB_TARGET simple_casadi_mpc::simple_casadi_mpc)
+    else()
+      set(ARG_LIB_TARGET simple_casadi_mpc)
+    endif()
+  endif()
+
+  # Allow users to pass additional solver-specific libraries if needed.
+  set(link_libs ${ARG_LINK_LIBS})
+
+  # Try to automatically link the casadi plugin library (brings solver deps).
+  if(NOT link_libs)
+    if(ARG_SOLVER_NAME)
+      set(solver_name ${ARG_SOLVER_NAME})
+    else()
+      # Keep default consistent with example codegen
+      set(solver_name fatrop)
+    endif()
+
+    # Collect possible casadi library directories to hint plugin lookup
+    set(casadi_lib_dirs)
+    foreach(casadi_target IN ITEMS casadi casadi::casadi)
+      if(TARGET ${casadi_target})
+        foreach(prop IN ITEMS IMPORTED_LOCATION_RELEASE IMPORTED_LOCATION)
+          get_target_property(_casadi_loc ${casadi_target} ${prop})
+          if(_casadi_loc)
+            get_filename_component(_casadi_dir ${_casadi_loc} DIRECTORY)
+            list(APPEND casadi_lib_dirs ${_casadi_dir})
+          endif()
+        endforeach()
+      endif()
+    endforeach()
+    list(REMOVE_DUPLICATES casadi_lib_dirs)
+
+    find_library(
+      casadi_nlpsol_${solver_name}_LIBRARY
+      NAMES casadi_nlpsol_${solver_name}
+      PATHS ${casadi_lib_dirs})
+    if(casadi_nlpsol_${solver_name}_LIBRARY)
+      # Ensure plugin is kept even with --as-needed to bring its dependencies.
+      list(APPEND link_libs "-Wl,--no-as-needed"
+           ${casadi_nlpsol_${solver_name}_LIBRARY} "-Wl,--as-needed")
+    endif()
+  endif()
+
   set(CODEGEN_DIR ${CMAKE_CURRENT_BINARY_DIR}/${name}_codegen)
-  file(MAKE_DIRECTORY ${CODEGEN_DIR}/coin-or)
-  file(
-    WRITE ${CODEGEN_DIR}/coin-or/IpStdCInterface.h
-    "#include <coin/IpStdCInterface.h>\nusing ipindex = Index;\nusing ipnumber = Number;\n"
-  )
+
+  # Ipopt codegen requires the coin-or header; provide a stub automatically.
+  set(extra_include_dirs)
+  if(solver_name STREQUAL "ipopt")
+    set(ipopt_stub_dir ${CODEGEN_DIR}/coin-or)
+    file(MAKE_DIRECTORY ${ipopt_stub_dir})
+    file(
+      WRITE ${ipopt_stub_dir}/IpStdCInterface.h
+      "#include <coin/IpStdCInterface.h>\nusing ipindex = Index;\nusing ipnumber = Number;\n"
+    )
+    list(APPEND extra_include_dirs ${ipopt_stub_dir})
+  endif()
 
   add_executable(${name}_codegen_bin ${codegen_cpp})
   if(ARG_INCLUDE_DIRS)
     target_include_directories(${name}_codegen_bin PRIVATE ${ARG_INCLUDE_DIRS})
   endif()
 
-  # TODO: ソルバーごとのライブラリリンクをユーザーに任せてるので隠蔽・自動化する
   target_link_libraries(
-    ${name}_codegen_bin PRIVATE casadi Eigen3::Eigen ${PROJECT_NAME}
-                                ${ARG_LINK_LIBS})
+    ${name}_codegen_bin PRIVATE casadi Eigen3::Eigen ${ARG_LIB_TARGET}
+                                ${link_libs})
 
   add_custom_command(
     OUTPUT ${CODEGEN_DIR}/${ARG_EXPORT_SOLVER_NAME}.c
@@ -44,9 +95,8 @@ function(add_simple_casadi_mpc_codegen name codegen_cpp)
   set_source_files_properties(${CODEGEN_DIR}/${ARG_EXPORT_SOLVER_NAME}.c
                               PROPERTIES LANGUAGE CXX COMPILE_OPTIONS "-w")
   target_include_directories(${name}_compiled_solver
-                             PRIVATE ${CODEGEN_DIR} ${IPOPT_INCLUDE_DIRS})
-  target_link_libraries(${name}_compiled_solver
-                        PRIVATE casadi ${IPOPT_LIBRARIES} ${ARG_LINK_LIBS})
+                             PRIVATE ${CODEGEN_DIR} ${extra_include_dirs})
+  target_link_libraries(${name}_compiled_solver PRIVATE casadi ${link_libs})
   target_compile_options(${name}_compiled_solver PRIVATE -fpermissive)
   set_target_properties(${name}_compiled_solver
                         PROPERTIES OUTPUT_NAME ${ARG_EXPORT_SOLVER_NAME})

--- a/example/cartpole_mpc_codegen.cpp
+++ b/example/cartpole_mpc_codegen.cpp
@@ -5,12 +5,12 @@ int main() {
   using namespace simple_casadi_mpc;
 
   // solver name
-  const std::string solver_name = "ipopt";
+  const std::string solver_name = "fatrop";
 
   // solver option
-  auto solver_config = MPC::default_ipopt_config();
-  // solver_config["fatrop.tol"] = 1e-4;
-  // solver_config["fatrop.acceptable_tol"] = 5e-4;
+  auto solver_config = MPC::default_fatrop_config();
+  solver_config["fatrop.tol"] = 1e-4;
+  solver_config["fatrop.acceptable_tol"] = 5e-4;
 
   // generated solver name
   const std::string export_solver_name = "cartpole_solver";

--- a/example/cartpole_mpc_codegen.cpp
+++ b/example/cartpole_mpc_codegen.cpp
@@ -5,12 +5,12 @@ int main() {
   using namespace simple_casadi_mpc;
 
   // solver name
-  const std::string solver_name = "fatrop";
+  const std::string solver_name = "ipopt";
 
   // solver option
-  auto solver_config = MPC::default_fatrop_config();
-  solver_config["fatrop.tol"] = 1e-4;
-  solver_config["fatrop.acceptable_tol"] = 5e-4;
+  auto solver_config = MPC::default_ipopt_config();
+  // solver_config["fatrop.tol"] = 1e-4;
+  // solver_config["fatrop.acceptable_tol"] = 5e-4;
 
   // generated solver name
   const std::string export_solver_name = "cartpole_solver";


### PR DESCRIPTION
Closes #5\n\n- Install codegen macro and package config so find_package exposes add_simple_casadi_mpc_codegen without extra deps\n- Auto-link casadi solver plugins (fatrop/ipopt) and stub IpStdCInterface for ipopt codegen\n- Simplify example CMakeLists and document CompiledMPC usage in README