### PR TITLE
Add CI build workflow for CasADi and simple_casadi_mpc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     env:
       CASADI_PREFIX: /home/runner/casadi-install
       MATPLOTLIBCPP17_PREFIX: /home/runner/matplotlibcpp17-install
@@ -89,33 +89,9 @@ jobs:
           make -j$(nproc)
           make install
 
-      - name: Build simple_casadi_mpc with EXAMPLES
+      - name: Build simple_casadi_mpc
         env:
-          LD_LIBRARY_PATH: ${{ env.CASADI_PREFIX }}/lib
-        run: |
-          mkdir -p build && cd build
-          cmake .. \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_PREFIX_PATH="$CASADI_PREFIX;$MATPLOTLIBCPP17_PREFIX" \
-            -DBUILD_EXAMPLES=ON \
-            -DBUILD_BENCHMARKS=OFF
-          make -j$(nproc)
-
-      - name: Build simple_casadi_mpc with BENCHMARKS
-        env:
-          LD_LIBRARY_PATH: ${{ env.CASADI_PREFIX }}/lib
-        run: |
-          rm -rf build
-          mkdir -p build && cd build
-          cmake .. \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_PREFIX_PATH="$CASADI_PREFIX;$MATPLOTLIBCPP17_PREFIX" \
-            -DBUILD_EXAMPLES=OFF \
-            -DBUILD_BENCHMARKS=ON
-          make -j$(nproc)
-
-      - name: Build simple_casadi_mpc with ALL
-        env:
+          LIBRARY_PATH: ${{ env.CASADI_PREFIX }}/lib
           LD_LIBRARY_PATH: ${{ env.CASADI_PREFIX }}/lib
         run: |
           rm -rf build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    env:
+      CASADI_PREFIX: /home/runner/casadi-install
+      MATPLOTLIBCPP17_PREFIX: /home/runner/matplotlibcpp17-install
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,7 +47,7 @@ jobs:
           ARGS=""
           # Release build
           ARGS="$ARGS -DCMAKE_BUILD_TYPE=Release"
-          ARGS="$ARGS -DCMAKE_INSTALL_PREFIX=$HOME/casadi-install"
+          ARGS="$ARGS -DCMAKE_INSTALL_PREFIX=$CASADI_PREFIX"
 
           # NLP Solver
           ARGS="$ARGS -DWITH_IPOPT=ON"
@@ -81,39 +84,45 @@ jobs:
           mkdir build && cd build
           cmake .. \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX=$HOME/matplotlibcpp17-install \
+            -DCMAKE_INSTALL_PREFIX=$MATPLOTLIBCPP17_PREFIX \
             -DADD_DEMO=OFF
           make -j$(nproc)
           make install
 
       - name: Build simple_casadi_mpc with EXAMPLES
+        env:
+          LD_LIBRARY_PATH: ${{ env.CASADI_PREFIX }}/lib
         run: |
           mkdir -p build && cd build
           cmake .. \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_PREFIX_PATH="$HOME/casadi-install;$HOME/matplotlibcpp17-install" \
+            -DCMAKE_PREFIX_PATH="$CASADI_PREFIX;$MATPLOTLIBCPP17_PREFIX" \
             -DBUILD_EXAMPLES=ON \
             -DBUILD_BENCHMARKS=OFF
           make -j$(nproc)
 
       - name: Build simple_casadi_mpc with BENCHMARKS
+        env:
+          LD_LIBRARY_PATH: ${{ env.CASADI_PREFIX }}/lib
         run: |
           rm -rf build
           mkdir -p build && cd build
           cmake .. \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_PREFIX_PATH="$HOME/casadi-install;$HOME/matplotlibcpp17-install" \
+            -DCMAKE_PREFIX_PATH="$CASADI_PREFIX;$MATPLOTLIBCPP17_PREFIX" \
             -DBUILD_EXAMPLES=OFF \
             -DBUILD_BENCHMARKS=ON
           make -j$(nproc)
 
       - name: Build simple_casadi_mpc with ALL
+        env:
+          LD_LIBRARY_PATH: ${{ env.CASADI_PREFIX }}/lib
         run: |
           rm -rf build
           mkdir -p build && cd build
           cmake .. \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_PREFIX_PATH="$HOME/casadi-install;$HOME/matplotlibcpp17-install" \
+            -DCMAKE_PREFIX_PATH="$CASADI_PREFIX;$MATPLOTLIBCPP17_PREFIX" \
             -DBUILD_EXAMPLES=ON \
             -DBUILD_BENCHMARKS=ON
           make -j$(nproc)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,119 @@
+name: build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            git cmake gcc g++ gfortran pkg-config \
+            liblapack-dev coinor-libipopt-dev \
+            libeigen3-dev \
+            python3-dev python3-numpy python3-matplotlib \
+            pybind11-dev
+
+      - name: Cache CasADi
+        id: cache-casadi
+        uses: actions/cache@v4
+        with:
+          path: ~/casadi-install
+          key: casadi-${{ runner.os }}-${{ hashFiles('install_casadi.sh') }}
+
+      - name: Build and install CasADi
+        if: steps.cache-casadi.outputs.cache-hit != 'true'
+        run: |
+          git clone https://github.com/casadi/casadi.git ~/casadi
+          cd ~/casadi
+          mkdir build && cd build
+
+          ARGS=""
+          # Release build
+          ARGS="$ARGS -DCMAKE_BUILD_TYPE=Release"
+          ARGS="$ARGS -DCMAKE_INSTALL_PREFIX=$HOME/casadi-install"
+
+          # NLP Solver
+          ARGS="$ARGS -DWITH_IPOPT=ON"
+
+          # MPC-related (FATROP + BLASFEO)
+          ARGS="$ARGS -DWITH_FATROP=ON -DWITH_BUILD_FATROP=ON"
+          ARGS="$ARGS -DWITH_BLASFEO=ON -DWITH_BUILD_BLASFEO=ON"
+          ARGS="$ARGS -DWITH_LAPACK=ON"
+
+          # Disable unnecessary features for faster build
+          ARGS="$ARGS -DWITH_SUNDIALS=OFF"
+          ARGS="$ARGS -DWITH_FMI2=OFF"
+          ARGS="$ARGS -DWITH_FMI3=OFF"
+          ARGS="$ARGS -DWITH_DEEPBIND=OFF"
+          ARGS="$ARGS -DWITH_DEPRECATED_FEATURES=OFF"
+          ARGS="$ARGS -DWITH_EXAMPLES=OFF"
+
+          cmake .. $ARGS
+          make -j$(nproc)
+          make install
+
+      - name: Cache matplotlibcpp17
+        id: cache-matplotlibcpp17
+        uses: actions/cache@v4
+        with:
+          path: ~/matplotlibcpp17-install
+          key: matplotlibcpp17-${{ runner.os }}-v1
+
+      - name: Build and install matplotlibcpp17
+        if: steps.cache-matplotlibcpp17.outputs.cache-hit != 'true'
+        run: |
+          git clone https://github.com/soblin/matplotlibcpp17.git ~/matplotlibcpp17
+          cd ~/matplotlibcpp17
+          mkdir build && cd build
+          cmake .. \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=$HOME/matplotlibcpp17-install \
+            -DADD_DEMO=OFF
+          make -j$(nproc)
+          make install
+
+      - name: Build simple_casadi_mpc with EXAMPLES
+        run: |
+          mkdir -p build && cd build
+          cmake .. \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_PREFIX_PATH="$HOME/casadi-install;$HOME/matplotlibcpp17-install" \
+            -DBUILD_EXAMPLES=ON \
+            -DBUILD_BENCHMARKS=OFF
+          make -j$(nproc)
+
+      - name: Build simple_casadi_mpc with BENCHMARKS
+        run: |
+          rm -rf build
+          mkdir -p build && cd build
+          cmake .. \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_PREFIX_PATH="$HOME/casadi-install;$HOME/matplotlibcpp17-install" \
+            -DBUILD_EXAMPLES=OFF \
+            -DBUILD_BENCHMARKS=ON
+          make -j$(nproc)
+
+      - name: Build simple_casadi_mpc with ALL
+        run: |
+          rm -rf build
+          mkdir -p build && cd build
+          cmake .. \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_PREFIX_PATH="$HOME/casadi-install;$HOME/matplotlibcpp17-install" \
+            -DBUILD_EXAMPLES=ON \
+            -DBUILD_BENCHMARKS=ON
+          make -j$(nproc)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,8 @@ jobs:
         env:
           LIBRARY_PATH: ${{ env.CASADI_PREFIX }}/lib
           LD_LIBRARY_PATH: ${{ env.CASADI_PREFIX }}/lib
+          CPATH: ${{ env.CASADI_PREFIX }}/include
+          CPLUS_INCLUDE_PATH: ${{ env.CASADI_PREFIX }}/include
         run: |
           rm -rf build
           mkdir -p build && cd build

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 .vscode/
 .cache/
 doc/build/
+casadi/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # simple_casadi_mpc
 
+[![build](https://github.com/Kotakku/simple_casadi_mpc/actions/workflows/build.yml/badge.svg)](https://github.com/Kotakku/simple_casadi_mpc/actions/workflows/build.yml)
+[![docs](https://github.com/Kotakku/simple_casadi_mpc/actions/workflows/docs.yml/badge.svg)](https://github.com/Kotakku/simple_casadi_mpc/actions/workflows/docs.yml)
+
 Lightweight C++ utilities for building and solving MPC problems with CasADi. Includes runtime MPC, JIT-compiled MPC, and CMake-integrated compiled MPC solvers.
 
 ## Dependencies
-- CasADi ([install script example](https://github.com/Kotakku/OptimLibSetupHub/blob/master/CasADi/install_casadi.sh))
+- CasADi ([install script](install_casadi.sh))
 - IPOPT or FATROP (optional solver backends)
 - Eigen3
 - Python3 + NumPy + pybind11

--- a/install_casadi.sh
+++ b/install_casadi.sh
@@ -1,0 +1,292 @@
+#!/bin/sh
+
+# Install dependencies
+sudo apt install -y git cmake gcc g++ gfortran pkg-config liblapack-dev pkg-config coinor-libipopt-dev --install-recommends
+
+# Clone CasADi repository
+git clone https://github.com/casadi/casadi.git casadi
+
+cd casadi
+mkdir -p build
+cd build
+
+ARGS=""
+
+#==============================================================================
+# Build Type
+#==============================================================================
+ARGS="$ARGS -DCMAKE_BUILD_TYPE=Release"
+# ARGS="$ARGS -DCMAKE_BUILD_TYPE=Debug"
+
+# Install prefix (default: /usr/local)
+# ARGS="$ARGS -DCMAKE_INSTALL_PREFIX=$HOME/local"
+
+#==============================================================================
+# Language Bindings (Front-ends)
+#==============================================================================
+# Python bindings
+# ARGS="$ARGS -DWITH_PYTHON=ON"
+# ARGS="$ARGS -DWITH_PYTHON3=ON"
+# ARGS="$ARGS -DWITH_PYTHON_GIL_RELEASE=ON"
+
+# MATLAB bindings
+# ARGS="$ARGS -DWITH_MATLAB=ON"
+
+# Octave bindings (experimental)
+# ARGS="$ARGS -DWITH_OCTAVE=ON"
+
+# JSON front-end
+# ARGS="$ARGS -DWITH_JSON=ON"
+
+#==============================================================================
+# Parallelization
+#==============================================================================
+# OpenMP support
+# ARGS="$ARGS -DWITH_OPENMP=ON"
+
+# POSIX Threads support
+# ARGS="$ARGS -DWITH_THREAD=ON"
+
+# Thread-safe symbolics (may impact performance)
+# ARGS="$ARGS -DWITH_THREADSAFE_SYMBOLICS=ON"
+
+# OpenCL support (experimental)
+# ARGS="$ARGS -DWITH_OPENCL=ON"
+
+#==============================================================================
+# NLP Solvers (Nonlinear Programming)
+#==============================================================================
+# IPOPT - Interior Point Optimizer (requires coinor-libipopt-dev)
+ARGS="$ARGS -DWITH_IPOPT=ON"
+# ARGS="$ARGS -DWITH_BUILD_IPOPT=ON"
+
+# BONMIN - Basic Open-source Nonlinear Mixed INteger programming
+# ARGS="$ARGS -DWITH_BONMIN=ON"
+# ARGS="$ARGS -DWITH_BUILD_BONMIN=ON"
+
+# KNITRO - commercial solver
+# ARGS="$ARGS -DWITH_KNITRO=ON"
+
+# SNOPT - commercial solver
+# ARGS="$ARGS -DWITH_SNOPT=ON"
+
+# WORHP - commercial solver
+# ARGS="$ARGS -DWITH_WORHP=ON"
+
+# MadNLP - Nonlinear solver in Julia
+# ARGS="$ARGS -DWITH_MADNLP=ON"
+
+# SLEQP - Sequential Linearization Equality-constrained QP
+# ARGS="$ARGS -DWITH_SLEQP=ON"
+# ARGS="$ARGS -DWITH_BUILD_SLEQP=ON"
+
+# Alpaqa - proximal gradient-based solver
+# ARGS="$ARGS -DWITH_ALPAQA=ON"
+# ARGS="$ARGS -DWITH_BUILD_ALPAQA=ON"
+
+#==============================================================================
+# QP Solvers (Quadratic Programming)
+#==============================================================================
+# qpOASES - online active set strategy QP solver (included)
+# ARGS="$ARGS -DWITH_QPOASES=ON"
+# ARGS="$ARGS -DWITH_NO_QPOASES_BANNER=ON"
+
+# OSQP - Operator Splitting QP solver
+# ARGS="$ARGS -DWITH_OSQP=ON"
+# ARGS="$ARGS -DWITH_BUILD_OSQP=ON"
+
+# PROXQP - Proximal QP solver
+# ARGS="$ARGS -DWITH_PROXQP=ON"
+# ARGS="$ARGS -DWITH_BUILD_PROXQP=ON"
+
+# SuperSCS - Splitting Conic Solver (included)
+# ARGS="$ARGS -DWITH_SUPERSCS=ON"
+# ARGS="$ARGS -DWITH_BUILD_SUPERSCS=ON"
+
+# DAQP - Dual Active-set QP solver
+# ARGS="$ARGS -DWITH_DAQP=ON"
+# ARGS="$ARGS -DWITH_BUILD_DAQP=ON"
+
+# Clarabel - Interior point conic solver
+# ARGS="$ARGS -DWITH_CLARABEL=ON"
+# ARGS="$ARGS -DWITH_BUILD_CLARABEL=ON"
+
+# blockSQP - Block-structured SQP solver (included)
+# ARGS="$ARGS -DWITH_BLOCKSQP=ON"
+
+#==============================================================================
+# LP Solvers (Linear Programming)
+#==============================================================================
+# HiGHS - High performance LP/MIP solver
+# ARGS="$ARGS -DWITH_HIGHS=ON"
+# ARGS="$ARGS -DWITH_BUILD_HIGHS=ON"
+
+# CLP - COIN-OR LP solver
+# ARGS="$ARGS -DWITH_CLP=ON"
+# ARGS="$ARGS -DWITH_BUILD_CLP=ON"
+
+# CBC - COIN-OR Branch and Cut (MIP solver)
+# ARGS="$ARGS -DWITH_CBC=ON"
+# ARGS="$ARGS -DWITH_BUILD_CBC=ON"
+
+# CPLEX - IBM commercial solver
+# ARGS="$ARGS -DWITH_CPLEX=ON"
+
+# GUROBI - commercial solver
+# ARGS="$ARGS -DWITH_GUROBI=ON"
+
+# DSDP - Semidefinite programming solver
+# ARGS="$ARGS -DWITH_DSDP=ON"
+# ARGS="$ARGS -DWITH_BUILD_DSDP=ON"
+
+#==============================================================================
+# MPC-related Solvers (Model Predictive Control)
+#==============================================================================
+# FATROP - Fast Trajectory Optimization (for OCP)
+ARGS="$ARGS -DWITH_FATROP=ON"
+ARGS="$ARGS -DWITH_BUILD_FATROP=ON"
+
+# HPIPM - High-Performance Interior Point Method
+# ARGS="$ARGS -DWITH_HPIPM=ON"
+# ARGS="$ARGS -DWITH_BUILD_HPIPM=ON"
+
+#==============================================================================
+# Linear Algebra Libraries
+#==============================================================================
+# LAPACK
+ARGS="$ARGS -DWITH_LAPACK=ON"
+# ARGS="$ARGS -DWITH_BUILD_LAPACK=ON"
+
+# BLASFEO - Basic Linear Algebra Subroutines For Embedded Optimization
+ARGS="$ARGS -DWITH_BLASFEO=ON"
+ARGS="$ARGS -DWITH_BUILD_BLASFEO=ON"
+
+# CSparse - Concise Sparse matrix package (included, default ON)
+# ARGS="$ARGS -DWITH_CSPARSE=ON"
+# ARGS="$ARGS -DWITH_BUILD_CSPARSE=ON"
+
+# Sundials - CVODES/IDAS integrators (included, default ON)
+# Not needed for MPC code generation, disable to reduce build time
+ARGS="$ARGS -DWITH_SUNDIALS=OFF"
+
+# MUMPS - MUltifrontal Massively Parallel Sparse direct Solver
+# ARGS="$ARGS -DWITH_MUMPS=ON"
+# ARGS="$ARGS -DWITH_BUILD_MUMPS=ON"
+
+# HSL - Harwell Subroutine Library (requires license)
+# ARGS="$ARGS -DWITH_HSL=ON"
+
+# SPRAL - Sparse Parallel Robust Algorithms Library
+# ARGS="$ARGS -DWITH_SPRAL=ON"
+# ARGS="$ARGS -DWITH_BUILD_SPRAL=ON"
+
+# Metis - Graph partitioning (used by some solvers)
+# ARGS="$ARGS -DWITH_BUILD_METIS=ON"
+
+#==============================================================================
+# Code Generation & Interfaces
+#==============================================================================
+# Dynamic loading of functions (default ON)
+# ARGS="$ARGS -DWITH_DL=ON"
+
+# FMI 2.0 binary import support (default ON)
+# Not needed for MPC, disable to reduce build time
+ARGS="$ARGS -DWITH_FMI2=OFF"
+
+# FMI 3.0 binary import support (default ON)
+ARGS="$ARGS -DWITH_FMI3=OFF"
+
+# TinyXML (included, default ON)
+# ARGS="$ARGS -DWITH_TINYXML=ON"
+# ARGS="$ARGS -DWITH_BUILD_TINYXML=ON"
+
+# Clang JIT compilation
+# ARGS="$ARGS -DWITH_CLANG=ON"
+
+# AMPL interface
+# ARGS="$ARGS -DWITH_AMPL=ON"
+
+# MATLAB IPC interface
+# ARGS="$ARGS -DWITH_MATLAB_IPC=ON"
+
+# Rumoca - Modelica compiler
+# ARGS="$ARGS -DWITH_RUMOCA=ON"
+# ARGS="$ARGS -DWITH_BUILD_RUMOCA=ON"
+
+#==============================================================================
+# Additional Libraries
+#==============================================================================
+# Eigen3 - Linear algebra library
+# ARGS="$ARGS -DWITH_BUILD_EIGEN3=ON"
+
+# SLICOT - Control and systems library
+# ARGS="$ARGS -DWITH_SLICOT=ON"
+
+# ZLIB - Compression library
+# ARGS="$ARGS -DWITH_ZLIB=ON"
+# ARGS="$ARGS -DWITH_BUILD_ZLIB=ON"
+
+# LIBZIP - ZIP archive library
+# ARGS="$ARGS -DWITH_LIBZIP=ON"
+# ARGS="$ARGS -DWITH_BUILD_LIBZIP=ON"
+
+# GHC Filesystem - std::filesystem alternative
+# ARGS="$ARGS -DWITH_GHC_FILESYSTEM=ON"
+# ARGS="$ARGS -DWITH_BUILD_GHC_FILESYSTEM=ON"
+
+#==============================================================================
+# Build Options
+#==============================================================================
+# Self-contained install directory
+# ARGS="$ARGS -DWITH_SELFCONTAINED=ON"
+
+# SO version for shared library (default ON)
+# ARGS="$ARGS -DWITH_SO_VERSION=ON"
+
+# Build examples (default ON)
+ARGS="$ARGS -DWITH_EXAMPLES=OFF"
+
+# DEEPBIND for plugin loading (default ON, useful for MATLAB)
+# Not needed without MATLAB
+ARGS="$ARGS -DWITH_DEEPBIND=OFF"
+
+# Deprecated features support (default ON)
+# Not needed for new development
+ARGS="$ARGS -DWITH_DEPRECATED_FEATURES=OFF"
+
+#==============================================================================
+# Development & Debugging
+#==============================================================================
+# Extra warnings (-Wall -Wextra)
+# ARGS="$ARGS -DWITH_EXTRA_WARNINGS=ON"
+
+# Treat warnings as errors (-Werror)
+# ARGS="$ARGS -DWITH_WERROR=ON"
+
+# Extra runtime checks (for developers)
+# ARGS="$ARGS -DWITH_EXTRA_CHECKS=ON"
+
+# Coverage report
+# ARGS="$ARGS -DWITH_COVERAGE=ON"
+
+# Reference counting warnings
+# ARGS="$ARGS -DWITH_REFCOUNT_WARNINGS=ON"
+
+# Linting support
+# ARGS="$ARGS -DWITH_LINT=ON"
+
+# Spell-checking support
+# ARGS="$ARGS -DWITH_SPELL=ON"
+
+# clang-tidy support
+# ARGS="$ARGS -DWITH_CLANG_TIDY=ON"
+
+# Documentation generation
+# ARGS="$ARGS -DWITH_DOC=ON"
+
+#==============================================================================
+# Build and Install
+#==============================================================================
+cmake .. $ARGS
+make -j$(nproc)
+sudo make install

--- a/install_casadi.sh
+++ b/install_casadi.sh
@@ -290,3 +290,6 @@ ARGS="$ARGS -DWITH_DEPRECATED_FEATURES=OFF"
 cmake .. $ARGS
 make -j$(nproc)
 sudo make install
+
+# Update library cache so linker can find libcasadi
+sudo ldconfig


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow (`build.yml`) to build and verify the project
- Add `install_casadi.sh` script with documented CMake options for CasADi
- Add `casadi/` to `.gitignore`

## CI Workflow Details
The workflow:
1. Installs system dependencies (cmake, gcc, gfortran, IPOPT, Eigen3, pybind11, etc.)
2. Builds CasADi from source with optimized options:
   - IPOPT, FATROP, BLASFEO enabled
   - Unnecessary features disabled (Sundials, FMI, etc.) for faster build
3. Builds matplotlibcpp17 from source
4. Builds simple_casadi_mpc with:
   - `BUILD_EXAMPLES=ON`
   - `BUILD_BENCHMARKS=ON`

## Test plan
- [ ] Verify CI workflow runs successfully on push/PR
- [ ] Verify all examples build correctly
- [ ] Verify all benchmarks build correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)