### PR TITLE
feat: soft constraints via slack variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,13 @@ if(BUILD_EXAMPLES)
     PRIVATE casadi Eigen3::Eigen ${PROJECT_NAME} pybind11::embed
             matplotlibcpp17::matplotlibcpp17)
 
+  add_executable(diff_drive_soft_constraint_example
+                 example/diff_drive_soft_constraint_example.cpp)
+  target_link_libraries(
+    diff_drive_soft_constraint_example
+    PRIVATE casadi Eigen3::Eigen ${PROJECT_NAME} pybind11::embed
+            matplotlibcpp17::matplotlibcpp17)
+
   add_executable(cartpole_mpc_jit_example example/cartpole_mpc_jit_example.cpp)
   target_link_libraries(
     cartpole_mpc_jit_example

--- a/README.md
+++ b/README.md
@@ -97,6 +97,18 @@ From: [example/diff_drive_mpc_example.cpp](https://github.com/Kotakku/simple_cas
 
 ![](gallery/example/diff_drive.gif)
 
+### diff_drive_soft_constraint_example
+Same diff-drive setup with a single circular obstacle, comparing `add_constraint` (hard) and `soft_add_constraint` (soft) for the obstacle. With a large penalty weight the soft formulation matches the hard one; with a small weight the optimizer prefers cutting through the obstacle if the tracking gain dominates the violation cost.
+
+From: [example/diff_drive_soft_constraint_example.cpp](https://github.com/Kotakku/simple_casadi_mpc/blob/main/example/diff_drive_soft_constraint_example.cpp)
+
+## Soft constraints
+`Problem::soft_add_constraint(type, func, w1, w2)` introduces non-negative per-stage slack variables `s ≥ 0` and adds `w1 · 1ᵀs + 0.5 · w2 · sᵀs` to the cost.
+- Inequality `g(x,u) ≤ 0` becomes `g − s ≤ 0`.
+- Equality `h(x,u) = 0` becomes `|h| ≤ s`, encoded as `h − s ≤ 0` and `−h − s ≤ 0`.
+
+The default `w2 = 0` gives a pure L1 (exact) penalty; setting `w2 > 0` adds an L2 (smooth) term. Large `w1` recovers hard-constraint behavior; small `w1` allows the optimizer to trade violation against the rest of the cost. Hard `add_constraint` and soft `soft_add_constraint` can be mixed on the same problem.
+
 ## Benchmarks
 Runtime comparisons for cartpole MPC solver variants.
 

--- a/example/diff_drive_soft_constraint_example.cpp
+++ b/example/diff_drive_soft_constraint_example.cpp
@@ -1,0 +1,164 @@
+#include "simple_casadi_mpc/simple_casadi_mpc.hpp"
+#include <casadi/casadi.hpp>
+#include <chrono>
+#include <iostream>
+#include <matplotlibcpp17/pyplot.h>
+#include <pybind11/embed.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+
+using namespace pybind11::literals;
+
+class DiffDriveSoftProb : public simple_casadi_mpc::Problem {
+public:
+  // soft=true で障害物制約を soft_add_constraint で追加する。
+  DiffDriveSoftProb(bool soft, double w1, double w2)
+      : Problem(DynamicsType::ContinuesRK4, 5, 2, 40, 0.1) {
+    using namespace casadi;
+    x_ref = parameter("x_ref", 5, 1);
+
+    Q = DM::diag({10, 10, 6, 0.5, 0.1});
+    R = DM::diag({0.01, 0.01});
+    Qf = DM::diag({10, 10, 6, 0.5, 0.1});
+
+    Eigen::VectorXd u_ub = (Eigen::VectorXd(2) << 2.0, 2.0).finished();
+    set_input_bound(-u_ub, u_ub);
+    Eigen::VectorXd x_ub = (Eigen::VectorXd(5) << inf, inf, inf, 2.0, 1.5).finished();
+    set_state_bound(-x_ub, x_ub);
+
+    auto obs =
+        std::bind(&DiffDriveSoftProb::obstacle, this, std::placeholders::_1, std::placeholders::_2);
+    if (soft) {
+      soft_add_constraint(ConstraintType::Inequality, obs, w1, w2);
+    } else {
+      add_constraint(ConstraintType::Inequality, obs);
+    }
+  }
+
+  virtual casadi::MX dynamics(casadi::MX x, casadi::MX u) override {
+    using namespace casadi;
+    auto theta = x(2);
+    auto v = x(3);
+    auto omega = x(4);
+    return vertcat(v * cos(theta), v * sin(theta), omega, u(0), u(1));
+  }
+
+  // 直線経路にわずかに被る位置に障害物を 1 つ置く。hard なら避けるが、soft の重みが
+  // 小さければ突っ切るほうが最適になる、という挙動差が見える。
+  // (xy - center)^T (xy - center) >= radius^2 を g(x,u) <= 0 形式で表現
+  static constexpr double obs_cx = 0.0;
+  static constexpr double obs_cy = 0.15;
+  static constexpr double obs_r = 0.3;
+
+  casadi::MX obstacle(casadi::MX x, casadi::MX u) {
+    (void)u;
+    using namespace casadi;
+    MX xy = x(Slice(0, 2));
+    DM center = DM::zeros(2);
+    center(0) = obs_cx;
+    center(1) = obs_cy;
+    return -(mtimes((xy - center).T(), (xy - center)) - obs_r * obs_r);
+  }
+
+  virtual casadi::MX stage_cost(casadi::MX x, casadi::MX u, size_t k) override {
+    (void)k;
+    using namespace casadi;
+    MX e = x - x_ref;
+    return dt() * (0.5 * mtimes(e.T(), mtimes(Q, e)) + 0.5 * mtimes(u.T(), mtimes(R, u)));
+  }
+
+  virtual casadi::MX terminal_cost(casadi::MX x) override {
+    using namespace casadi;
+    MX e = x - x_ref;
+    return 0.5 * mtimes(e.T(), mtimes(Qf, e));
+  }
+
+  casadi::MX x_ref;
+  casadi::DM Q, R, Qf;
+};
+
+struct Trajectory {
+  std::vector<double> x, y;
+  double min_clearance = std::numeric_limits<double>::infinity();
+};
+
+// 障害物中心からの距離 - radius の最小値（負だと衝突）
+static double clearance(double x, double y, double cx, double cy, double radius) {
+  return std::hypot(x - cx, y - cy) - radius;
+}
+
+static Trajectory rollout(simple_casadi_mpc::MPC &mpc, simple_casadi_mpc::Problem &prob,
+                          const casadi::DMDict &param_list, Eigen::VectorXd x0, size_t sim_len,
+                          double dt) {
+  Trajectory traj;
+  traj.x.reserve(sim_len);
+  traj.y.reserve(sim_len);
+  for (size_t i = 0; i < sim_len; ++i) {
+    Eigen::VectorXd u = mpc.solve(x0, param_list);
+    x0 = prob.simulate(x0, u, dt);
+    traj.x.push_back(x0[0]);
+    traj.y.push_back(x0[1]);
+    traj.min_clearance = std::min(traj.min_clearance,
+                                  clearance(x0[0], x0[1], DiffDriveSoftProb::obs_cx,
+                                            DiffDriveSoftProb::obs_cy, DiffDriveSoftProb::obs_r));
+  }
+  return traj;
+}
+
+int main() {
+  using namespace simple_casadi_mpc;
+  pybind11::scoped_interpreter guard{};
+  auto plt = matplotlibcpp17::pyplot::import();
+
+  casadi::DMDict param_list;
+  // 2 つの障害物のあいだを通り抜ける必要があるゴール
+  param_list["x_ref"] = std::vector<double>{1, 0.0, 0, 0, 0};
+  Eigen::VectorXd x0(5);
+  x0 << -1, 0.0, 0, 0, 0;
+
+  const double dt = 0.05;
+  const size_t sim_len = 80;
+
+  auto run = [&](const std::string &label, bool soft, double w1, double w2) {
+    auto prob = std::make_shared<DiffDriveSoftProb>(soft, w1, w2);
+    MPC mpc(prob);
+    auto t0 = std::chrono::steady_clock::now();
+    auto traj = rollout(mpc, *prob, param_list, x0, sim_len, dt);
+    auto t1 = std::chrono::steady_clock::now();
+    double sec = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() * 1e-3;
+    std::cout << "[" << label << "] min_clearance=" << traj.min_clearance << " final=("
+              << traj.x.back() << ", " << traj.y.back() << ")"
+              << " elapsed=" << sec << " s" << std::endl;
+    return traj;
+  };
+
+  // hard: 障害物を確実に避けて遠回りする
+  auto traj_hard = run("hard", false, 0.0, 0.0);
+  // soft (重み大): 実質 hard と同じ挙動
+  auto traj_soft_high = run("soft w1=1e4", true, 1e4, 0.0);
+  // soft (重み小): 障害物を切り抜けるルートが最適になるはず
+  auto traj_soft_low = run("soft w1=1e0", true, 1e0, 0.0);
+
+  // Plot
+  plt.figure();
+  plt.gca().set_aspect(pybind11::make_tuple(1.0));
+  auto draw_circle = [&](double cx, double cy, double r) {
+    std::vector<double> xs(64), ys(64);
+    for (size_t i = 0; i < xs.size(); ++i) {
+      double a = 2 * M_PI * i / (xs.size() - 1);
+      xs[i] = cx + r * std::cos(a);
+      ys[i] = cy + r * std::sin(a);
+    }
+    plt.plot(pybind11::make_tuple(xs, ys, "k-"));
+  };
+  draw_circle(DiffDriveSoftProb::obs_cx, DiffDriveSoftProb::obs_cy, DiffDriveSoftProb::obs_r);
+  plt.plot(pybind11::make_tuple(traj_hard.x, traj_hard.y), pybind11::dict("label"_a = "hard"));
+  plt.plot(pybind11::make_tuple(traj_soft_high.x, traj_soft_high.y),
+           pybind11::dict("label"_a = "soft w1=1e4"));
+  plt.plot(pybind11::make_tuple(traj_soft_low.x, traj_soft_low.y),
+           pybind11::dict("label"_a = "soft w1=1e0"));
+  plt.legend();
+  plt.show();
+  return 0;
+}

--- a/example/diff_drive_soft_constraint_example.cpp
+++ b/example/diff_drive_soft_constraint_example.cpp
@@ -112,7 +112,7 @@ int main() {
   auto plt = matplotlibcpp17::pyplot::import();
 
   casadi::DMDict param_list;
-  // 2 つの障害物のあいだを通り抜ける必要があるゴール
+  // 直線経路上の障害物をまたぐ目標位置
   param_list["x_ref"] = std::vector<double>{1, 0.0, 0, 0, 0};
   Eigen::VectorXd x0(5);
   x0 << -1, 0.0, 0, 0, 0;

--- a/include/simple_casadi_mpc/simple_casadi_mpc.hpp
+++ b/include/simple_casadi_mpc/simple_casadi_mpc.hpp
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include <map>
 #include <memory>
+#include <numeric>
 #include <vector>
 
 namespace simple_casadi_mpc {
@@ -153,6 +154,17 @@ public:
     }
   }
 
+  // Soft constraint: introduces non-negative slack variables s >= 0 and adds
+  //   penalty = w1 * 1^T s + 0.5 * w2 * s^T s
+  // to the cost. For inequality g(x,u) <= 0 the constraint becomes g - s <= 0.
+  // For equality h(x,u) = 0 it becomes |h| <= s, i.e. (h - s <= 0) and (-h - s <= 0).
+  // Pure L1 (exact) penalty is the default; set w2 > 0 to add an L2 (smooth) term.
+  void soft_add_constraint(ConstraintType type,
+                           std::function<casadi::MX(casadi::MX, casadi::MX)> constraint,
+                           double w1 = 1e3, double w2 = 0.0) {
+    soft_constraints_.push_back({type, constraint, w1, w2});
+  }
+
   // k番目のステージコスト
   virtual casadi::MX stage_cost(casadi::MX x, casadi::MX u, size_t k) {
     (void)x;
@@ -207,6 +219,14 @@ private:
   using ConstraintFunc = std::function<casadi::MX(casadi::MX, casadi::MX)>;
   std::vector<ConstraintFunc> equality_constrinats_;
   std::vector<ConstraintFunc> inequality_constrinats_;
+
+  struct SoftConstraint {
+    ConstraintType type;
+    ConstraintFunc func;
+    double w1;
+    double w2;
+  };
+  std::vector<SoftConstraint> soft_constraints_;
 
   using LUbound = std::pair<Eigen::VectorXd, Eigen::VectorXd>;
   std::vector<LUbound> u_bounds_;
@@ -432,9 +452,50 @@ protected:
     for (auto &con : prob_->inequality_constrinats_) {
       g_k_vec.push_back(con(x_k, u_k));
     }
+
+    // ソフト制約用のスラック変数を per-stage に確保し、対応する不等式を g_k に追加する。
+    // - 不等式 g(x,u) <= 0 -> g - s <= 0
+    // - 等式  h(x,u)  = 0 -> h - s <= 0 かつ -h - s <= 0  (|h| <= s)
+    // s >= 0 は w 側の bound で強制し、ペナルティ w1*1^T s + 0.5*w2*s^T s をコストに加算する。
+    std::vector<casadi_int> soft_sizes;
+    soft_sizes.reserve(prob_->soft_constraints_.size());
+    for (auto &sc : prob_->soft_constraints_) {
+      soft_sizes.push_back(sc.func(x_k, u_k).size1());
+    }
+    const casadi_int n_s_total =
+        std::accumulate(soft_sizes.begin(), soft_sizes.end(), static_cast<casadi_int>(0));
+
+    std::vector<MX> Ss;
+    MX s_k;
+    if (n_s_total > 0) {
+      s_k = MX::sym("s_k", n_s_total, 1);
+      Ss.reserve(N);
+      for (casadi_int i = 0; i < N; ++i) {
+        Ss.push_back(MX::sym("S_" + std::to_string(i), n_s_total, 1));
+      }
+
+      casadi_int s_offset = 0;
+      for (size_t i = 0; i < prob_->soft_constraints_.size(); ++i) {
+        auto &sc = prob_->soft_constraints_[i];
+        const casadi_int m = soft_sizes[i];
+        MX s_part = s_k(Slice(s_offset, s_offset + m));
+        MX c_val = sc.func(x_k, u_k);
+        if (sc.type == Problem::ConstraintType::Inequality) {
+          g_k_vec.push_back(c_val - s_part);
+        } else {
+          g_k_vec.push_back(c_val - s_part);
+          g_k_vec.push_back(-c_val - s_part);
+        }
+        s_offset += m;
+      }
+    }
+
     MX g_k = vertcat(g_k_vec);
 
     std::vector<MX> G_inputs = {x_k, u_k};
+    if (n_s_total > 0) {
+      G_inputs.push_back(s_k);
+    }
     G_inputs.insert(G_inputs.end(), params_mx.begin(), params_mx.end());
     Function G_constraints("G_constraints", G_inputs, {g_k});
 
@@ -460,12 +521,34 @@ protected:
 
     // Terminal cost
     MX terminal_val = prob_->terminal_cost(Xs[N]);
-    MX J = J_stage + terminal_val;
+
+    // ソフト制約のスラック変数に対するペナルティコスト
+    MX penalty_cost = 0;
+    if (n_s_total > 0) {
+      for (casadi_int k = 0; k < N; ++k) {
+        casadi_int off = 0;
+        for (size_t i = 0; i < prob_->soft_constraints_.size(); ++i) {
+          auto &sc = prob_->soft_constraints_[i];
+          const casadi_int m = soft_sizes[i];
+          MX sk_part = Ss[k](Slice(off, off + m));
+          penalty_cost = penalty_cost + sc.w1 * sum1(sk_part);
+          if (sc.w2 != 0.0) {
+            penalty_cost = penalty_cost + 0.5 * sc.w2 * dot(sk_part, sk_part);
+          }
+          off += m;
+        }
+      }
+    }
+
+    MX J = J_stage + terminal_val + penalty_cost;
 
     // Path constraints
     MX G_path;
     if (!g_k.is_empty()) {
       std::vector<MX> G_map_inputs = {X(Slice(), Slice(0, N)), U};
+      if (n_s_total > 0) {
+        G_map_inputs.push_back(horzcat(Ss));
+      }
       for (auto &param : params_mx) {
         G_map_inputs.push_back(repmat(param, 1, N));
       }
@@ -474,10 +557,13 @@ protected:
 
     // 4. NLP construction
     std::vector<MX> w_vec;
-    w_vec.reserve(2 * N + 1);
+    w_vec.reserve((n_s_total > 0 ? 3 : 2) * N + 1);
     for (casadi_int i = 0; i < N; ++i) {
       w_vec.push_back(Xs[i]);
       w_vec.push_back(Us[i]);
+      if (n_s_total > 0) {
+        w_vec.push_back(Ss[i]);
+      }
     }
     w_vec.push_back(Xs[N]);
     MX w = vertcat(w_vec);
@@ -509,6 +595,10 @@ protected:
                          u_bounds[i].first.data() + nu);
       ubw_numeric.insert(ubw_numeric.end(), u_bounds[i].second.data(),
                          u_bounds[i].second.data() + nu);
+      if (n_s_total > 0) {
+        lbw_numeric.insert(lbw_numeric.end(), n_s_total, 0.0);
+        ubw_numeric.insert(ubw_numeric.end(), n_s_total, inf);
+      }
     }
     // Bounds for x_N
     lbw_numeric.insert(lbw_numeric.end(), x_bounds[N - 1].first.data(),
@@ -537,6 +627,15 @@ protected:
         ubg_numeric.insert(ubg_numeric.end(), con_val.size1(), 0.0);
 
         equality_.insert(equality_.end(), con_val.size1(), false);
+      }
+      // ソフト制約の path 制約 (どちらも片側不等式 [-inf, 0])
+      for (size_t s_i = 0; s_i < prob_->soft_constraints_.size(); ++s_i) {
+        const casadi_int m = soft_sizes[s_i];
+        const casadi_int rows =
+            (prob_->soft_constraints_[s_i].type == Problem::ConstraintType::Inequality) ? m : 2 * m;
+        lbg_numeric.insert(lbg_numeric.end(), rows, -inf);
+        ubg_numeric.insert(ubg_numeric.end(), rows, 0.0);
+        equality_.insert(equality_.end(), rows, false);
       }
     }
 


### PR DESCRIPTION
## Summary
- Add `Problem::soft_add_constraint(type, func, w1, w2)` which introduces non-negative per-stage slack variables and adds `w1 · 1ᵀs + 0.5 · w2 · sᵀs` to the cost.
  - Inequality `g(x,u) ≤ 0` is encoded as `g − s ≤ 0`.
  - Equality `h(x,u) = 0` is encoded as `|h| ≤ s` via `(h − s ≤ 0)` and `(−h − s ≤ 0)`.
  - Slack `s ≥ 0` is enforced via variable bounds, so the L1 term reduces to `sum(s)`.
  - Default `w2 = 0` gives a pure L1 (exact) penalty; `w2 > 0` adds an L2 (smooth) term.
- Decision variable layout is extended to `[X_0, U_0, S_0, ..., X_{N−1}, U_{N−1}, S_{N−1}, X_N]`. `X_0` and `U_0` keep their original offsets, so `solve()` and the JIT/Compiled variants work unchanged.
- Hard `add_constraint` and soft `soft_add_constraint` can be mixed on the same problem.
- New example `example/diff_drive_soft_constraint_example.cpp` compares hard vs. soft obstacle constraints with two penalty weights.
- README gains an `Examples` entry and a short `Soft constraints` section describing the API.

## Test plan
- [x] `cmake -DBUILD_EXAMPLES=ON ..` configures
- [x] `make diff_drive_soft_constraint_example` builds
- [x] `make diff_drive_mpc_example double_integrator_mpc_example cartpole_mpc_example` still build (no regression for hard-constraint paths — `n_s_total == 0` short-circuits all slack code)
- [x] Example run output: hard `min_clearance ≈ 0` (avoids), soft `w1=1e4` `min_clearance ≈ 0` (matches hard), soft `w1=1e0` `min_clearance ≈ −0.12` (cuts through), as expected