### PR TITLE
ci: add semantic PR title check and expand pre-commit hooks

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,21 @@
+name: Semantic PR
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,5 @@
+default: true
+MD013: false # line-length
+MD024: false # no-duplicate-heading
+MD033: false # no-inline-html
+MD041: false # first-line-h1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,54 @@
+ci:
+  autofix_commit_msg: "style(pre-commit): autofix"
+
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
-  hooks:
-    - id: trailing-whitespace
-    - id: end-of-file-fixer
-    - id: check-yaml
-    - id: check-added-large-files
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: detect-private-key
+      - id: mixed-line-ending
 
-# CMake formatting
-- repo: https://github.com/cheshirekow/cmake-format-precommit
-  rev: "v0.6.13"
-  hooks:
-    - id: cmake-format
-      additional_dependencies: [pyyaml]
-      files: "(\\.cmake|CMakeLists.txt)(\\.in)?$"
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.33.0
+    hooks:
+      - id: markdownlint
+        args: [-c, .markdownlint.yaml, --fix]
 
-- repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v16.0.0
-  hooks:
-    - id: clang-format
-      types_or: [c++, c]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.0-alpha.6
+    hooks:
+      - id: prettier
+
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.30.0
+    hooks:
+      - id: yamllint
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.9.0.2
+    hooks:
+      - id: shellcheck
+
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.6.0-2
+    hooks:
+      - id: shfmt
+        args: [-w, -s, -i=4]
+
+  - repo: https://github.com/cheshirekow/cmake-format-precommit
+    rev: v0.6.13
+    hooks:
+      - id: cmake-format
+        additional_dependencies: [pyyaml]
+        files: "(\\.cmake|CMakeLists.txt)(\\.in)?$"
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v16.0.0
+    hooks:
+      - id: clang-format
+        types_or: [c++, c]

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,10 @@
+extends: default
+
+rules:
+  document-start: disable
+  line-length: disable
+  truthy:
+    check-keys: false
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: disable


### PR DESCRIPTION
## Summary
- Add `.github/workflows/semantic-pr.yml` using `amannn/action-semantic-pull-request@v5` to enforce Conventional Commits-style PR titles (e.g. `feat: xxx`).
- Expand `.pre-commit-config.yaml` with hooks reused from the ROS2 setup (ROS-specific ones excluded): `check-merge-conflict`, `detect-private-key`, `mixed-line-ending`, `markdownlint`, `prettier`, `yamllint`, `shellcheck`, `shfmt`. Also add `ci.autofix_commit_msg` block for [pre-commit.ci](https://pre-commit.ci/).
- Add `.yamllint.yaml` (relaxed rules: disable `line-length` / `document-start`, allow GHA `on:` key via `truthy.check-keys: false`) and `.markdownlint.yaml` (disable `MD013/024/033/041`).

## Notes
- This PR adds config only; running `pre-commit run --all-files` against existing files (README/sh/CMake/C++ etc.) will be done in a follow-up PR.
- After merging, [pre-commit.ci](https://pre-commit.ci/) needs to be installed on the repo for autofix to work. Once enabled, its check (and the `Validate PR title` check) can be added to required status checks alongside `build`.

## Test plan
- [ ] `build` workflow passes on this PR
- [ ] After merge: install pre-commit.ci app on the repo
- [ ] After merge: update branch protection on `main` to require `build`, `Validate PR title`, and pre-commit.ci checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)