### PR TITLE
feat: add stage-specific add_constraint_at / add_soft_constraint_at

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,18 @@ add_constraint(ConstraintType::Equality, [](casadi::MX x, casadi::MX u) {
 });
 ```
 
+To apply a constraint only to a subset of stages, use `add_constraint_at(type, func, start, end)`. Range semantics match `set_input_bound`:
+
+```cpp
+// Only at stage 0 (single-stage form, omit `end`)
+add_constraint_at(ConstraintType::Equality,
+                  [&](casadi::MX x, casadi::MX) { return x - x_target; }, 0);
+
+// Only on stages [N-3, N) (terminal-band)
+add_constraint_at(ConstraintType::Inequality,
+                  [&](casadi::MX x, casadi::MX) { return x - x_safe; }, N - 3, N);
+```
+
 ### Soft path constraints
 
 `add_soft_constraint(type, func, w1, w2)` introduces non-negative per-stage slack variables $s \ge 0$ and adds the penalty $w_1 \mathbf{1}^\top s + \tfrac{1}{2} w_2 s^\top s$ to the cost. The original constraint is relaxed as:
@@ -169,6 +181,14 @@ add_soft_constraint(ConstraintType::Inequality, my_constraint, /*w1=*/1e2, /*w2=
 ```
 
 The default `w2 = 0` gives a pure L1 (exact) penalty; `w2 > 0` adds an L2 (smooth) term. Large `w1` recovers hard-constraint behavior; small `w1` lets the optimizer trade violation against the rest of the cost. Hard `add_constraint` and soft `add_soft_constraint` may be mixed on the same problem.
+
+Stage-specific variants are also available — same `start`/`end` semantics as `add_constraint_at`:
+
+```cpp
+add_soft_constraint_at(ConstraintType::Inequality, my_constraint,
+                       /*w1=*/1e3, /*w2=*/0.0,
+                       /*start=*/N - 3, /*end=*/N); // only the last 3 stages
+```
 
 ### Usage for CompiledMPC via CMake
 

--- a/include/simple_casadi_mpc/simple_casadi_mpc.hpp
+++ b/include/simple_casadi_mpc/simple_casadi_mpc.hpp
@@ -84,6 +84,10 @@ public:
   /// Each entry of `_dts` is the integration step \f$\Delta t_k\f$ used between
   /// stage \f$k\f$ and \f$k+1\f$. Use this overload when the prediction
   /// horizon spans non-uniform time intervals (e.g. coarse-to-fine schedules).
+  /// @param dyn_type discretization scheme used by @ref dynamics.
+  /// @param _nx state dimension.
+  /// @param _nu control dimension.
+  /// @param _horizon number of stages in the optimization (N).
   /// @param _dts per-stage time steps, must have size == `_horizon`.
   Problem(DynamicsType dyn_type, size_t _nx, size_t _nu, size_t _horizon, std::vector<double> _dts)
       : dyn_type_(dyn_type), nx_(_nx), nu_(_nu), horizon_(_horizon), dts_(std::move(_dts)) {
@@ -219,10 +223,28 @@ public:
   /// @param constrinat callable returning the constraint vector at one stage.
   void add_constraint(ConstraintType type,
                       std::function<casadi::MX(casadi::MX, casadi::MX)> constrinat) {
+    add_constraint_at(type, constrinat, /*start=*/-1, /*end=*/-1);
+  }
+
+  /// @brief Add a hard path constraint applied only at the specified stage range.
+  ///
+  /// Range semantics match @ref set_input_bound:
+  /// - `start == -1, end == -1`           → all stages \f$[0, N)\f$ (same as @ref add_constraint).
+  /// - `start != -1, end == -1`           → only stage `start`.
+  /// - `start != -1, end != -1`           → stages \f$[\text{start}, \text{end})\f$.
+  ///
+  /// Internally the constraint is still attached to the per-stage `g(x, u)`
+  /// vector (so the symbolic structure remains uniform across stages); the
+  /// path-constraint bound is set to \f$[-\infty, +\infty]\f$ on inactive
+  /// stages so it does not influence the solution.
+  void add_constraint_at(ConstraintType type,
+                         std::function<casadi::MX(casadi::MX, casadi::MX)> constraint, int start,
+                         int end = -1) {
+    auto mask = stage_mask(start, end);
     if (type == ConstraintType::Equality) {
-      equality_constrinats_.push_back(constrinat);
+      equality_constraints_.push_back({constraint, std::move(mask)});
     } else {
-      inequality_constrinats_.push_back(constrinat);
+      inequality_constraints_.push_back({constraint, std::move(mask)});
     }
   }
 
@@ -248,7 +270,18 @@ public:
   void add_soft_constraint(ConstraintType type,
                            std::function<casadi::MX(casadi::MX, casadi::MX)> constraint,
                            double w1 = 1e3, double w2 = 0.0) {
-    soft_constraints_.push_back({type, constraint, w1, w2});
+    add_soft_constraint_at(type, constraint, w1, w2, /*start=*/-1, /*end=*/-1);
+  }
+
+  /// @brief Add a soft path constraint applied only at the specified stage range.
+  ///
+  /// Range semantics match @ref add_constraint_at. On inactive stages the
+  /// associated slack is forced to 0 (so the penalty contributes nothing) and
+  /// the relaxed constraint bound is set to \f$[-\infty, +\infty]\f$.
+  void add_soft_constraint_at(ConstraintType type,
+                              std::function<casadi::MX(casadi::MX, casadi::MX)> constraint,
+                              double w1, double w2, int start, int end = -1) {
+    soft_constraints_.push_back({type, constraint, w1, w2, stage_mask(start, end)});
   }
 
   /// @brief Stage cost \f$L(x_k, u_k, k;\,p)\f$ at step \f$k\f$. Default returns 0.
@@ -328,6 +361,14 @@ private:
     return {start, end};
   }
 
+  std::vector<bool> stage_mask(int start, int end) {
+    auto [s, e] = index_range(start, end);
+    std::vector<bool> mask(horizon_, false);
+    for (int k = s; k < e; ++k)
+      mask[k] = true;
+    return mask;
+  }
+
   const DynamicsType dyn_type_;
   const size_t nx_;
   const size_t nu_;
@@ -335,14 +376,20 @@ private:
   const std::vector<double> dts_;
 
   using ConstraintFunc = std::function<casadi::MX(casadi::MX, casadi::MX)>;
-  std::vector<ConstraintFunc> equality_constrinats_;
-  std::vector<ConstraintFunc> inequality_constrinats_;
+
+  struct PathConstraint {
+    ConstraintFunc func;
+    std::vector<bool> stage_mask; // size == horizon; true at stages where the constraint is active.
+  };
+  std::vector<PathConstraint> equality_constraints_;
+  std::vector<PathConstraint> inequality_constraints_;
 
   struct SoftConstraint {
     ConstraintType type;
     ConstraintFunc func;
     double w1;
     double w2;
+    std::vector<bool> stage_mask;
   };
   std::vector<SoftConstraint> soft_constraints_;
 
@@ -640,11 +687,19 @@ protected:
 
     // 制約一覧
     std::vector<MX> g_k_vec;
-    for (auto &con : prob_->equality_constrinats_) {
-      g_k_vec.push_back(con(x_k, u_k));
+    std::vector<casadi_int> equality_sizes; // size of each equality constraint (per stage)
+    std::vector<casadi_int> inequality_sizes;
+    equality_sizes.reserve(prob_->equality_constraints_.size());
+    inequality_sizes.reserve(prob_->inequality_constraints_.size());
+    for (auto &con : prob_->equality_constraints_) {
+      MX g_part = con.func(x_k, u_k);
+      equality_sizes.push_back(g_part.size1());
+      g_k_vec.push_back(g_part);
     }
-    for (auto &con : prob_->inequality_constrinats_) {
-      g_k_vec.push_back(con(x_k, u_k));
+    for (auto &con : prob_->inequality_constraints_) {
+      MX g_part = con.func(x_k, u_k);
+      inequality_sizes.push_back(g_part.size1());
+      g_k_vec.push_back(g_part);
     }
 
     // ソフト制約用のスラック変数を per-stage に確保し、対応する不等式を g_k に追加する。
@@ -870,8 +925,14 @@ protected:
       ubw_numeric.insert(ubw_numeric.end(), u_bounds[i].second.data(),
                          u_bounds[i].second.data() + nu);
       if (n_s_total > 0) {
-        lbw_numeric.insert(lbw_numeric.end(), n_s_total, 0.0);
-        ubw_numeric.insert(ubw_numeric.end(), n_s_total, inf);
+        // Slack bound is [0, inf] on stages where the soft constraint is
+        // active and [0, 0] (force s = 0) elsewhere.
+        for (size_t s_i = 0; s_i < prob_->soft_constraints_.size(); ++s_i) {
+          const casadi_int m = soft_sizes[s_i];
+          const bool active = prob_->soft_constraints_[s_i].stage_mask[i];
+          lbw_numeric.insert(lbw_numeric.end(), m, 0.0);
+          ubw_numeric.insert(ubw_numeric.end(), m, active ? inf : 0.0);
+        }
       }
     }
     // Bounds for x_N
@@ -886,29 +947,37 @@ protected:
     ubg_numeric.insert(ubg_numeric.end(), nx * N, 0.0);
     equality_.insert(equality_.end(), nx * N, true);
 
-    // Path constraints bounds
+    // Path constraints bounds. Inactive stages of staged constraints get
+    // bounds set to [-inf, +inf] so the constraint is symbolically present
+    // (uniform map structure) but does not influence the solution.
     for (casadi_int i = 0; i < N; ++i) {
-      for (auto &con : prob_->equality_constrinats_) {
-        auto con_val = con(x_k, u_k); // For getting size
-        lbg_numeric.insert(lbg_numeric.end(), con_val.size1(), 0.0);
-        ubg_numeric.insert(ubg_numeric.end(), con_val.size1(), 0.0);
-
-        equality_.insert(equality_.end(), con_val.size1(), true);
+      for (size_t ci = 0; ci < prob_->equality_constraints_.size(); ++ci) {
+        auto &con = prob_->equality_constraints_[ci];
+        const casadi_int sz = equality_sizes[ci];
+        const bool active = con.stage_mask[i];
+        lbg_numeric.insert(lbg_numeric.end(), sz, active ? 0.0 : -inf);
+        ubg_numeric.insert(ubg_numeric.end(), sz, active ? 0.0 : inf);
+        equality_.insert(equality_.end(), sz, active);
       }
-      for (auto &con : prob_->inequality_constrinats_) {
-        auto con_val = con(x_k, u_k); // For getting size
-        lbg_numeric.insert(lbg_numeric.end(), con_val.size1(), -inf);
-        ubg_numeric.insert(ubg_numeric.end(), con_val.size1(), 0.0);
-
-        equality_.insert(equality_.end(), con_val.size1(), false);
+      for (size_t ci = 0; ci < prob_->inequality_constraints_.size(); ++ci) {
+        auto &con = prob_->inequality_constraints_[ci];
+        const casadi_int sz = inequality_sizes[ci];
+        const bool active = con.stage_mask[i];
+        lbg_numeric.insert(lbg_numeric.end(), sz, -inf);
+        ubg_numeric.insert(ubg_numeric.end(), sz, active ? 0.0 : inf);
+        equality_.insert(equality_.end(), sz, false);
       }
-      // ソフト制約の path 制約 (どちらも片側不等式 [-inf, 0])
+      // Soft path constraints (both forms are one-sided inequalities <= 0).
+      // On inactive stages the bound is relaxed to [-inf, +inf]; combined
+      // with the slack pinned to [0, 0] above, this nulls the constraint and
+      // its penalty contribution at those stages.
       for (size_t s_i = 0; s_i < prob_->soft_constraints_.size(); ++s_i) {
+        auto &sc = prob_->soft_constraints_[s_i];
         const casadi_int m = soft_sizes[s_i];
-        const casadi_int rows =
-            (prob_->soft_constraints_[s_i].type == Problem::ConstraintType::Inequality) ? m : 2 * m;
+        const casadi_int rows = (sc.type == Problem::ConstraintType::Inequality) ? m : 2 * m;
+        const bool active = sc.stage_mask[i];
         lbg_numeric.insert(lbg_numeric.end(), rows, -inf);
-        ubg_numeric.insert(ubg_numeric.end(), rows, 0.0);
+        ubg_numeric.insert(ubg_numeric.end(), rows, active ? 0.0 : inf);
         equality_.insert(equality_.end(), rows, false);
       }
     }


### PR DESCRIPTION
Closes #25. Backward compatible.

## Summary
Adds stage-range overloads of the path-constraint adders so a constraint can be limited to a single stage or a contiguous \[start, end) range instead of being applied at every stage:

```cpp
prob->add_constraint_at(ConstraintType::Equality,
                        [](MX x, MX) { return x - x_target; },
                        /*start=*/0);                   // single stage
prob->add_constraint_at(ConstraintType::Inequality,
                        my_safety_g,
                        /*start=*/N - 3, /*end=*/N);    // last 3 stages
prob->add_soft_constraint_at(ConstraintType::Inequality,
                             my_obstacle_g,
                             /*w1=*/1e3, /*w2=*/0.0,
                             /*start=*/5, /*end=*/15);
```

Range semantics match `set_input_bound` (single index or `[start, end)`; `-1, -1` means all stages).

## Backward compatibility
The existing `add_constraint` / `add_soft_constraint` are now thin wrappers around the new `*_at` versions with an all-stages mask, so existing callers see no behavioural change.

## Internal mechanics
- `PathConstraint { func, stage_mask }` and `SoftConstraint { ..., stage_mask }` carry a per-stage activity mask.
- `build_with_map` still produces a single `G_constraints` mapped over `N` (the symbolic structure stays uniform). Activity is enforced via the per-stage path-constraint bounds: inactive stages get `[-inf, +inf]` so the constraint is symbolically present but does not influence the solution.
- For staged soft constraints, the per-stage slack lower/upper bound is set to `[0, 0]` on inactive stages, pinning the slack to 0 → the penalty contribution is zero and the relaxed inequality is also nullified by `[-inf, +inf]` bounds.

## Test plan
- [x] All build targets compile (interface lib, every example, benchmark).
- [x] `doxygen Doxyfile` runs without warnings.
- [x] Off-tree smoke test exercises:
  - baseline (no extra constraint) → u₀ at lower input bound (-1)
  - existing `add_constraint` (`u ≥ 0.5` everywhere) → u₀ clamped to 0.5
  - new `add_constraint_at(..., 3, 6)` → u₀ stays at -1 (constraint only inside the prediction)
  - new `add_constraint_at(..., 0)` (single stage) → u₀ clamped to 0.5
  - new `add_soft_constraint_at(..., 0)` with weak weight → u₀ stays at -1 (penalty is overridden)
  - existing `add_soft_constraint` with strong weight → u₀ ≈ 0.5 (matches hard constraint)
- [ ] CI `build` / `Validate PR title` / `build-and-deploy`.

## Notes
- README "Hard path constraints" / "Soft path constraints" sections updated with usage snippets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)