### PR TITLE
ci: pass a PAT to release-please so it can fire downstream CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,3 +17,11 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # Use a Personal Access Token so commits / PRs created by this
+          # workflow trigger downstream workflows (build, Validate PR title,
+          # docs). The default GITHUB_TOKEN intentionally suppresses those to
+          # avoid recursion, which would leave required status checks unrun on
+          # release PRs. Falls back to the default token if the secret is not
+          # set, so the workflow keeps working out-of-the-box (just without
+          # downstream CI on release PRs).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}


### PR DESCRIPTION
Follow-up to #33. The default \`GITHUB_TOKEN\` is intentionally blocked by GitHub from triggering downstream workflows for PRs / commits it creates, which left the required \`build\` and \`Validate PR title\` checks **unrun** on PR #34 — so the release PR could not be merged.

## Fix
Wire \`secrets.RELEASE_PLEASE_TOKEN\` (a fine-grained PAT with \`contents: write\` + \`pull-requests: write\` on this repo) into the action via:

\`\`\`yaml
token: \${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
\`\`\`

The fallback to \`github.token\` keeps the workflow working out-of-the-box (matching the previous behaviour) when the secret isn't set, and uses the PAT when it is — at which point release-please's commits / PRs trigger downstream workflows like a normal contributor's would.

## After merging
- The next \`Release Please\` run on \`main\` will use the PAT.
- It updates PR #34, which now triggers \`build\` / \`Validate PR title\` / \`build-and-deploy\`.
- Once those go green, PR #34 (\`chore: release v1.0.0\`) becomes mergeable.

## Test plan
- [ ] CI \`build\` / \`Validate PR title\` / \`build-and-deploy\` pass on this PR.
- [ ] After merge: PR #34 receives a fresh release-please update with running CI checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)